### PR TITLE
use prebid ajax instead of fetch as fetch is not supported in IE10

### DIFF
--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -3,6 +3,7 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 import { config } from 'src/config';
 import { BANNER } from 'src/mediaTypes';
 import { REPO_AND_VERSION } from 'src/constants';
+import { ajax } from 'src/ajax';
 
 const BIDDER_CODE = 'sortable';
 const SERVER_URL = 'c.deployads.com';
@@ -129,13 +130,9 @@ export const spec = {
   },
 
   onTimeout(details) {
-    fetch(`//${SERVER_URL}/prebid/timeout`, {
+    ajax(`//${SERVER_URL}/prebid/timeout`, null, JSON.stringify(details), {
       method: 'POST',
-      body: JSON.stringify(details),
-      mode: 'no-cors',
-      headers: new Headers({
-        'Content-Type': 'text/plain'
-      })
+      contentType: 'text/plain'
     });
   }
 };

--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -131,8 +131,7 @@ export const spec = {
 
   onTimeout(details) {
     ajax(`//${SERVER_URL}/prebid/timeout`, null, JSON.stringify(details), {
-      method: 'POST',
-      contentType: 'text/plain'
+      method: 'POST'
     });
   }
 };


### PR DESCRIPTION
## Type of change
- [x ] Other

## Description of change
fetch isn't supported by Internet Explorer 10 or 11, and prebid supports IE 10+ (not sure if this is a problem of our adapter in prebid 1.x)

Served prebid locally, tested on lenshero and saw winning bid and its ad. Tested hello_world.html but empty bid was returned.