### PR TITLE
SOR-233 Sortable bid adapter supports passing OpenRTB bidder extension to users

### DIFF
--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -124,6 +124,9 @@ export const spec = {
           } else if (bid.nurl) {
             bidObj.adUrl = bid.nurl;
           }
+          if (bid.ext) {
+            bidObj[BIDDER_CODE] = bid.ext;
+          }
           sortableBids.push(bidObj);
         });
       });

--- a/test/spec/modules/sortableBidAdapter_spec.js
+++ b/test/spec/modules/sortableBidAdapter_spec.js
@@ -255,5 +255,15 @@ describe('sortableBidAdapter', function() {
       let result = spec.interpretResponse(response);
       expect(result.length).to.equal(0);
     });
+
+    it('should keep custom properties', () => {
+      const customProperties = {test: 'a test message', param: {testParam: 1}};
+      const expectedResult = Object.assign({}, expectedBid, {[spec.code]: customProperties});
+      const response = makeResponse();
+      response.body.seatbid[0].bid[0].ext = customProperties;
+      const result = spec.interpretResponse(response);
+      expect(result.length).to.equal(1);
+      expect(result[0]).to.deep.equal(expectedResult);
+    });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Sortable bid adapter passes extra bidder information returned from server, so that Sortable user may access such information.

Follow the suggested approach by Prebid.js team of using `bid[adapterName][customProperty]`. I assume `adapterName` here is the adapter code, i.e. `sortable`

- [x] official adapter submission
