### PR TITLE
SOR-1241 test cactus native ads

### DIFF
--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -26,7 +26,9 @@ function buildNativeRequest(nativeMediaType) {
   if (img) {
     assets.push(setAssetRequired(img, {
       img: {
-        type: 3 // Main
+        type: 3, // Main
+        wmin: 1,
+        hmin: 1
       }
     }));
   }

--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -59,7 +59,7 @@ function interpretNativeResponse(response) {
   if (response.link) {
     native.clickUrl = response.link.url;
   }
-  utils._each(native.assets, asset => {
+  utils._each(response.assets, asset => {
     if (asset.title) {
       native.title = asset.title.text;
     }


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Note this is only test code and far from a real stable feature, so it could be changed anytime in future. We should not merge this to official Prebid.js without further development.

Adapter supports simple native requests comprising a title and an image without dimensions.
