### PR TITLE
SOR-1097 sortable prebid.js adapter sends timeout

### DIFF
--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -156,6 +156,9 @@ export const spec = {
         },
       },
     };
+    if (bidderRequest && bidderRequest.timeout > 0) {
+      sortableBidReq.tmax = bidderRequest.timeout;
+    }
     if (gdprConsent) {
       sortableBidReq.user = {
         ext: {


### PR DESCRIPTION
## Type of change
- [x ] Feature

## Description of change
Sortable adapter sends Prebid timeout to server so that the server can bid timely.
