### PR TITLE
SOR-1294: Filter out imps with no size

### DIFF
--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -110,7 +110,7 @@ export const spec = {
           utils.isStr(key) && utils.isStr(bid.params.keywords[key])
         ))
     return !!(bid.params.tagId && haveSiteId && validFloor && validFloorSizeMap && validKeywords && bid.sizes &&
-      bid.sizes.every(sizeArr => sizeArr.length == 2 && sizeArr.every(num => utils.isNumber(num))));
+      bid.sizes.length > 0 && bid.sizes.every(sizeArr => sizeArr.length == 2 && sizeArr.every(num => utils.isNumber(num))));
   },
 
   buildRequests: function(validBidReqs, bidderRequest) {

--- a/test/spec/modules/sortableBidAdapter_spec.js
+++ b/test/spec/modules/sortableBidAdapter_spec.js
@@ -57,6 +57,12 @@ describe('sortableBidAdapter', function() {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
+    it('should return false when sizes are empty', () => {
+      let bid = makeBid();
+      bid.sizes = [];
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
     it('should return false when require params are not passed', () => {
       let bid = makeBid();
       bid.params = {};


### PR DESCRIPTION
Check that bid.sizes has at least one element. Add a test for this.