### PR TITLE
SOR-2753: Use better way to get href of page

### DIFF
--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -177,12 +177,14 @@ export const spec = {
       return rv;
     });
     const gdprConsent = bidderRequest && bidderRequest.gdprConsent;
+    const href = bidderRequest && bidderRequest.refererInfo && bidderRequest.refererInfo.referer ?
+      bidderRequest.refererInfo.referer : loc.href;
     const sortableBidReq = {
       id: utils.getUniqueIdentifierStr(),
       imp: sortableImps,
       site: {
         domain: loc.hostname,
-        page: loc.href,
+        page: href,
         ref: utils.getTopWindowReferrer(),
         publisher: {
           id: globalSiteId || validBidReqs[0].params.siteId,

--- a/test/spec/modules/sortableBidAdapter_spec.js
+++ b/test/spec/modules/sortableBidAdapter_spec.js
@@ -151,7 +151,7 @@ describe('sortableBidAdapter', function() {
       'auctionId': '1d1a030790a475'
     }];
 
-    const request = spec.buildRequests(bidRequests);
+    const request = spec.buildRequests(bidRequests, {refererInfo: { referer: 'http://example.com/page?param=val' }});
     const requestBody = JSON.parse(request.data);
 
     it('sends bid request to our endpoint via POST', function () {
@@ -187,6 +187,11 @@ describe('sortableBidAdapter', function() {
         '728x90': 0.15,
         '300x250': 1.20
       });
+    });
+
+    it('sets domain and href correctly', function () {
+      expect(requestBody.site.domain).to.equal('localhost');
+      expect(requestBody.site.page).to.equal('http://example.com/page?param=val');
     });
 
     const videoBidRequests = [{
@@ -229,6 +234,11 @@ describe('sortableBidAdapter', function() {
       expect(video.minduration).to.equal(5);
       expect(video.maxduration).to.equal(10);
       expect(video.startdelay).to.equal(0);
+    });
+
+    it('sets domain and href correctly', function () {
+      expect(videoRequestBody.site.domain).to.equal('localhost');
+      expect(videoRequestBody.site.page).to.equal('http://localhost:9876/');
     });
   });
 


### PR DESCRIPTION
According to comment in Prebid, getTopWindowLocation is being deprecated
and we should use the refererInfo object instead. If that doesn't exist,
go back to using gTWL.

This should fix the issue for standalone customers, but won't take
effect until this change is merged back into the Prebid master branch
and customers update.

Add tests that check case where refererInfo exists and where it doesn't.

Container fix will be done separately/differently, since that version
doesn't appear to have access to refererInfo.